### PR TITLE
feat(ontoma): enable extraction of disease labels from curation table

### DIFF
--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -6,13 +6,19 @@ from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as f
 
+from src.literature.method.ontoma.utils import (
+    translate_special_characters,
+    clean_disease_label
+)
+
 if TYPE_CHECKING:
     from pyspark.sql import Column, DataFrame
 
 __all__ = [
     "extract_disease_entities",
     "extract_target_entities",
-    "extract_drug_entities"
+    "extract_drug_entities",
+    "extract_disease_curation"
 ]
 
 
@@ -239,6 +245,64 @@ def extract_drug_entities(drug_index: DataFrame) -> DataFrame:
             f.lit("CD").alias("entityType")
         )
         # cleanup
+        .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
+        .distinct()
+    )
+
+def extract_disease_curation(disease_curation: DataFrame) -> DataFrame:
+    """Process a disease curation table to extract disease entities.
+
+    It is expected that the disease curation table contains the SEMANTIC_TAG and PROPERTY_VALUE fields
+    as in the format mentioned here: https://github.com/opentargets/curation/blob/master/mappings/disease/README.md
+
+    Args:
+        disease_curation (DataFrame): DataFrame with the disease curation.
+    
+    Returns:
+        DataFrame: DataFrame with the extracted disease entities.
+    """
+    return (
+        disease_curation
+        # extract entities from relevant fields and annotate entity with score and nlpPipelineTrack
+        .select(
+            f.regexp_extract(
+                f.col("SEMANTIC_TAG"), r'^http.+/(\w+_\w+)$', 1
+            ).alias("entityId"),
+            _annotate_entity(
+                f.array(f.col("PROPERTY_VALUE")), 1.0, "term"
+            ).alias("curationTerm"),
+            _annotate_entity(
+                f.array(f.col("PROPERTY_VALUE")), 1.0, "symbol"
+            ).alias("curationSymbol")
+        )
+        # flatten and explode array of structs
+        .withColumn(
+            "entity",
+            f.explode(
+                f.flatten(
+                    f.array(
+                        f.col("curationTerm"),
+                        f.col("curationSymbol")
+                    )
+                )
+            )
+        )
+        # select relevant fields and specify entity type
+        .select(
+            f.col("entityId"),
+            clean_disease_label(
+                translate_special_characters(
+                    f.trim(
+                        f.col("entity.entityLabel")
+                    )
+                )
+            ).alias("entityLabel"),
+            f.col("entity.entityScore").alias("entityScore"),
+            f.col("entity.nlpPipelineTrack").alias("nlpPipelineTrack"),
+            f.lit("DS").alias("entityType")
+        )
+        # cleanup
+        .filter((f.col("entityId").isNotNull()) & (f.length("entityId") > 0))
         .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
         .distinct()
     )

--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -111,7 +111,11 @@ def extract_disease_entities(disease_index: DataFrame) -> DataFrame:
         # select relevant fields and specify entity type
         .select(
             f.col("entityId"),
-            f.col("entity.entityLabel").alias("entityLabel"),
+            translate_special_characters(
+                f.trim(
+                    f.col("entity.entityLabel")
+                )
+            ).alias("entityLabel"),
             f.col("entity.entityScore").alias("entityScore"),
             f.col("entity.nlpPipelineTrack").alias("nlpPipelineTrack"),
             f.lit("DS").alias("entityType")
@@ -177,7 +181,11 @@ def extract_target_entities(target_index: DataFrame) -> DataFrame:
         # select relevant fields and specify entity type
         .select(
             f.col("entityId"), 
-            f.col("entity.entityLabel").alias("entityLabel"), 
+            translate_special_characters(
+                f.trim(
+                    f.col("entity.entityLabel")
+                )
+            ).alias("entityLabel"),
             f.col("entity.entityScore").alias("entityScore"), 
             f.col("entity.nlpPipelineTrack").alias("nlpPipelineTrack"),
             f.lit("GP").alias("entityType")
@@ -239,7 +247,11 @@ def extract_drug_entities(drug_index: DataFrame) -> DataFrame:
         # select relevant fields and specify entity type
         .select(
             f.col("entityId"),
-            f.col("entity.entityLabel").alias("entityLabel"),
+            translate_special_characters(
+                f.trim(
+                    f.col("entity.entityLabel")
+                )
+            ).alias("entityLabel"),
             f.col("entity.entityScore").alias("entityScore"),
             f.col("entity.nlpPipelineTrack").alias("nlpPipelineTrack"),
             f.lit("CD").alias("entityType")

--- a/src/literature/method/ontoma/ontoma.py
+++ b/src/literature/method/ontoma/ontoma.py
@@ -14,6 +14,10 @@ from src.literature.method.ontoma.index_parsers import (
     extract_target_entities,
     extract_drug_entities
 )
+from src.literature.method.ontoma.utils import (
+    translate_special_characters,
+    clean_disease_label
+)
 from src.literature.method.ontoma.nlp_pipeline import NLPPipeline
 
 if TYPE_CHECKING:
@@ -190,7 +194,8 @@ class OnToma:
     @staticmethod
     def _extract_input_entities(
         df: DataFrame,
-        label_col_name: str
+        label_col_name: str,
+        type_col_name: str,
     ) -> DataFrame:
         """Extract entities from the provided dataframe.
 
@@ -199,6 +204,7 @@ class OnToma:
         Args:
             df (DataFrame): DataFrame containing entity labels to be extracted.
             label_col_name (str): Name of the column containing the entity labels.
+            type_col_name (str): Name of the column containing the type of the entity label.
         
         Returns:
             DataFrame: DataFrame with additional columns containing entity label and NLP pipeline track.
@@ -209,14 +215,15 @@ class OnToma:
                 {
                     # convert greek alphabet to english alphabet
                     # https://www.rapidtables.com/math/symbols/greek_alphabet.html
-                    "entityLabel": f.translate(
-                        f.col(label_col_name), 
-                        "αβγδεζηικλμνξπτυω", 
-                        "abgdezhiklmnxptuo"
-                    ),
+                    "entityLabel": translate_special_characters(f.trim(f.col(label_col_name))),
                     # all input entities will be normalised using both the term and symbol tracks of the nlp pipeline
                     "nlpPipelineTrack": f.explode(f.array(f.lit("term"), f.lit("symbol")))
                 }
+            )
+            .withColumn(
+                "entityLabel",
+                f.when(f.col(type_col_name) == "DS", clean_disease_label(f.col("entityLabel")))
+                .otherwise(f.col("entityLabel"))
             )
         )
 
@@ -270,7 +277,7 @@ class OnToma:
             raise ValueError("Unable to map the provided entity type(s).")
     
         # extract entities from input dataframe
-        extracted_entities = self._extract_input_entities(df, label_col_name)
+        extracted_entities = self._extract_input_entities(df, label_col_name, type_col_name)
 
         # normalise entities and join with entity lookup table
         mapped_entities = (

--- a/src/literature/method/ontoma/utils.py
+++ b/src/literature/method/ontoma/utils.py
@@ -41,9 +41,12 @@ def clean_disease_label(disease_label: Column) -> Column:
         Column: Column containing the disease label with prefixes removed.
     """
     return (
-        f.regexp_extract(
-            f.element_at(f.split(disease_label, "#"), -1), 
-            r'^(?:[A-Z]{1}[0-9]{2}[-.A-Z0-9]* |Chapter [IVX]+ )?(.+)$', 
-            1
-        )
+        f.when(
+            disease_label.contains("#"),
+            f.regexp_extract(
+                f.element_at(f.split(disease_label, "#"), -1), 
+                r'^(?:[A-Z]{1}[0-9]{2}[-.A-Z0-9]* |Chapter [IVX]+ )?(.+)$', 
+                1
+            )
+        ).otherwise(disease_label)
     )

--- a/src/literature/method/ontoma/utils.py
+++ b/src/literature/method/ontoma/utils.py
@@ -1,0 +1,49 @@
+"""Utility functions."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyspark.sql.functions as f
+
+if TYPE_CHECKING:
+    from pyspark.sql import Column
+
+
+def translate_special_characters(label: Column) -> Column:
+    """Translate greek alphabet and accented latin characters into latin alphabet.
+
+    Conversions are based on the following websites:
+    https://www.rapidtables.com/math/symbols/greek_alphabet.html
+    https://en.wikipedia.org/wiki/Latin-1_Supplement
+
+    Args:
+        label (Column): Column containing the label to be translated.
+
+    Returns:
+        Column: Column containing the translated label.
+    """
+    return (
+        f.translate(
+            label,
+            "αβγδεζηικλμνξπρτυωàèìòùáéíóúâêîôûäëïöüÀÈÌÒÙÁÉÍÓÚÂÊÎÔÛÄËÏÖÜãåõøÃÅÕØçñýÇÑÝ",
+            "abgdezhiklmnxprtuoaeiouaeiouaeiouaeiouAEIOUAEIOUAEIOUAEIOUaaooAAOOcnyCNY"
+        )
+    )
+
+def clean_disease_label(disease_label: Column) -> Column:
+    """Clean disease label by removing prefixes.
+
+    Args:
+        disease_label (Column): Column containing the disease label with prefixes.
+
+    Returns:
+        Column: Column containing the disease label with prefixes removed.
+    """
+    return (
+        f.regexp_extract(
+            f.element_at(f.split(disease_label, "#"), -1), 
+            r'^(?:[A-Z]{1}[0-9]{2}[-.A-Z0-9]* |Chapter [IVX]+ )?(.+)$', 
+            1
+        )
+    )


### PR DESCRIPTION
This PR adds the `extract_disease_curation` function to extract entities from a disease curation table. 

This PR also adds the utility functions `clean_disease_label` and `translate_special_characters`.