### PR TITLE
feat(ontoma): enable creation of identifier lookup tables from Open Targets indices

### DIFF
--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -8,7 +8,9 @@ import pyspark.sql.functions as f
 
 from src.literature.method.ontoma.utils import (
     translate_special_characters,
-    clean_disease_label
+    clean_disease_label,
+    filter_disease_crossrefs,
+    format_disease_identifier
 )
 
 if TYPE_CHECKING:
@@ -349,6 +351,60 @@ def extract_disease_curation(disease_curation: DataFrame) -> DataFrame:
         )
         # cleanup
         .filter((f.col("entityId").isNotNull()) & (f.length("entityId") > 0))
+        .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
+        .distinct()
+    )
+
+def as_disease_id_lut(disease_index:DataFrame) -> DataFrame:
+    """Generate disease id lookup table from the Open Targets disease index.
+
+    Args:
+        disease_index (DataFrame): Open Targets disease index.
+
+    Returns:
+        DataFrame: Disease id lookup table.
+    """
+    return (
+        disease_index
+        # extract entities from relevant fields and annotate entity with score and nlpPipelineTrack
+        .select(
+            f.col("id").alias("entityId"),
+            _annotate_entity(
+                f.array(f.col("id")), 1.0, "symbol"
+            ).alias("identifier"),
+            _annotate_entity(
+                f.col("dbXRefs"), 0.999, "symbol"
+            ).alias("crossRefs"),
+            _annotate_entity(
+                f.col("obsoleteXRefs"), 0.998, "symbol"
+            ).alias("obsoleteCrossRefs")
+        )
+        # flatten and explode array of structs
+        .withColumn(
+            "entity",
+            f.explode(
+                f.flatten(
+                    f.array(    
+                        f.col("identifier"),
+                        f.col("crossRefs"),
+                        f.col("obsoleteCrossRefs")
+                    )
+                )
+            )
+        )
+        # select relevant fields and specify entity type
+        .select(
+            f.col("entityId"),
+            f.upper(f.trim(f.col("entity.entityLabel"))).alias("entityLabel"),
+            f.col("entity.entityScore").alias("entityScore"),
+            f.col("entity.nlpPipelineTrack").alias("nlpPipelineTrack"),
+            f.lit("DS").alias("entityType")
+        )
+        # filter out disease crossrefs with irrelevant prefixes
+        .transform(filter_disease_crossrefs)
+        # format disease identifier to have consistent formatting
+        .withColumn("entityLabel", format_disease_identifier(f.col("entityLabel")))
+        # cleanup
         .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
         .distinct()
     )

--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -228,8 +228,7 @@ def extract_drug_entities(drug_index: DataFrame) -> DataFrame:
                     # if it's an EMA id, extract the last part
                     x["source"] == "EMA",
                     f.transform(x["ids"], lambda i: f.regexp_extract(i, r'.+/EPAR/(.+)', 1))
-                )
-                .otherwise(x["ids"])
+                ).otherwise(x["ids"])
             )
         )
         # extract entities from relevant fields and annotate entity with score and nlpPipelineTrack
@@ -364,7 +363,7 @@ def as_drug_id_lut(drug_index: DataFrame) -> DataFrame:
     """
     return (
         drug_index
-        # filter for sources that have ids
+        # filter crossReferences for sources that have ids
         .withColumn(
             "crossReferences", 
             f.filter(
@@ -378,15 +377,10 @@ def as_drug_id_lut(drug_index: DataFrame) -> DataFrame:
             f.transform(
                 f.col("crossReferences"),
                 lambda x: f.when(
-                    # if it's a chEBI id, append "CHEBI_" as a prefix
+                    # if it's a chEBI id, append "CHEBI" as a prefix
                     x["source"] == "chEBI",
-                    f.concat(f.lit("CHEBI_"), x["ids"][0])
-                ).when(
-                    # if it's a drugbank id, add an underscore between the prefix and the number
-                    x["source"] == "drugbank",
-                    f.regexp_replace(x["ids"][0], "DB", "DB_")
-                )
-                .otherwise(x["ids"][0])
+                    f.concat(f.lit("CHEBI"), x["ids"][0])
+                ).otherwise(x["ids"][0])
             )
         )
         # extract entities from relevant fields and annotate entity with score and nlpPipelineTrack

--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -207,6 +207,31 @@ def extract_drug_entities(drug_index: DataFrame) -> DataFrame:
     """
     return (
         drug_index
+         # filter crossReferences for sources that have labels
+        .withColumn(
+            "crossReferences", 
+            f.filter(
+                f.col("crossReferences"),
+                lambda x: x["source"].isin("DailyMed", "USAN", "EMA")
+            )
+        )
+        # transform array of structs to array of strings and format ids
+        .withColumn(
+            "crossReferences",
+            f.transform(
+                f.col("crossReferences"),
+                lambda x: f.when(
+                    # if it's a DailyMed or USAN id, replace spaces encoded as "%20"
+                    x["source"].isin("DailyMed", "USAN"),
+                    f.transform(x["ids"], lambda i: f.regexp_replace(i, "%20", " "))
+                ).when(
+                    # if it's an EMA id, extract the last part
+                    x["source"] == "EMA",
+                    f.transform(x["ids"], lambda i: f.regexp_extract(i, r'.+/EPAR/(.+)', 1))
+                )
+                .otherwise(x["ids"])
+            )
+        )
         # extract entities from relevant fields and annotate entity with score and nlpPipelineTrack
         .select(
             f.col("id").alias("entityId"),
@@ -227,7 +252,13 @@ def extract_drug_entities(drug_index: DataFrame) -> DataFrame:
             ).alias("synonymsTerm"),
             _annotate_entity(
                 f.col("synonyms"), 0.999, "symbol"
-            ).alias("synonymsSymbol")
+            ).alias("synonymsSymbol"),
+            _annotate_entity(
+                f.flatten(f.col("crossReferences")), 0.998, "term"
+            ).alias("crossReferencesTerm"),
+            _annotate_entity(
+                f.flatten(f.col("crossReferences")), 0.998, "symbol"
+            ).alias("crossReferencesSymbol")
         )
         # flatten and explode array of structs
         .withColumn(
@@ -240,7 +271,9 @@ def extract_drug_entities(drug_index: DataFrame) -> DataFrame:
                         f.col("tradeNamesTerm"),
                         f.col("tradeNamesSymbol"),
                         f.col("synonymsTerm"),
-                        f.col("synonymsSymbol")
+                        f.col("synonymsSymbol"),
+                        f.col("crossReferencesTerm"),
+                        f.col("crossReferencesSymbol")
                     )
                 )
             )
@@ -331,7 +364,7 @@ def as_drug_id_lut(drug_index: DataFrame) -> DataFrame:
     """
     return (
         drug_index
-        # filter for sources that are ids
+        # filter for sources that have ids
         .withColumn(
             "crossReferences", 
             f.filter(

--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -444,10 +444,10 @@ def as_target_id_lut(target_index: DataFrame) -> DataFrame:
         .select(
             f.col("id").alias("entityId"),
             _annotate_entity(
-                f.col("dbXrefs"), 1.0, "id"
+                f.col("dbXrefs"), 1.0, "symbol"
             ).alias("dbXrefs"),
             _annotate_entity(
-                f.col("proteinIds.id"), 1.0, "id"
+                f.col("proteinIds.id"), 1.0, "symbol"
             ).alias("proteinIds")
         )
         # flatten and explode array of structs
@@ -510,7 +510,7 @@ def as_drug_id_lut(drug_index: DataFrame) -> DataFrame:
         .select(
             f.col("id").alias("entityId"),
             _annotate_entity(
-                f.col("crossReferences"), 1.0, "id"
+                f.col("crossReferences"), 1.0, "symbol"
             ).alias("crossReferences")
         )
         # explode array of structs

--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -19,6 +19,7 @@ __all__ = [
     "extract_target_entities",
     "extract_drug_entities",
     "extract_disease_curation",
+    "as_target_id_lut",
     "as_drug_id_lut"
 ]
 
@@ -348,6 +349,72 @@ def extract_disease_curation(disease_curation: DataFrame) -> DataFrame:
         )
         # cleanup
         .filter((f.col("entityId").isNotNull()) & (f.length("entityId") > 0))
+        .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
+        .distinct()
+    )
+
+def as_target_id_lut(target_index: DataFrame) -> DataFrame:
+    """Generate target id lookup table from the Open Targets target index.
+
+    Args:
+        target_index (DataFrame): Open Targets target index.
+
+    Returns:
+        DataFrame: Target id lookup table.
+    """
+    return (
+        target_index
+        # filter out Xrefs with signalP as a source as only two possible ids (SignalP-TM and SignalP-noTM)
+        .withColumn(
+            "dbXrefs", 
+            f.filter(
+                f.col("dbXrefs"),
+                lambda x: x["source"] != "signalP"
+            )
+        )
+        # transform array of structs to array of strings and format ids
+        .withColumn(
+            "dbXrefs",
+            f.transform(
+                f.col("dbXrefs"),
+                lambda x: f.when(
+                    # if it's a HGNC id, append "HGNC" as a prefix
+                    x["source"] == "HGNC",
+                    f.concat(f.lit("HGNC"), x["id"])
+                ).otherwise(x["id"])
+            )
+        )
+        # extract entities from relevant fields and annotate entity with score and nlpPipelineTrack
+        .select(
+            f.col("id").alias("entityId"),
+            _annotate_entity(
+                f.col("dbXrefs"), 1.0, "id"
+            ).alias("dbXrefs"),
+            _annotate_entity(
+                f.col("proteinIds.id"), 1.0, "id"
+            ).alias("proteinIds")
+        )
+        # flatten and explode array of structs
+        .withColumn(
+            "entity",
+            f.explode(
+                f.flatten(
+                    f.array(
+                        f.col("dbXrefs"),
+                        f.col("proteinIds")
+                    )
+                )
+            )
+        )
+        # select relevant fields and specify entity type
+        .select(
+            f.col("entityId"),
+            f.col("entity.entityLabel").alias("entityLabel"),
+            f.col("entity.entityScore").alias("entityScore"),
+            f.col("entity.nlpPipelineTrack").alias("nlpPipelineTrack"),
+            f.lit("GP").alias("entityType")
+        )
+        # cleanup
         .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
         .distinct()
     )

--- a/src/literature/method/ontoma/index_parsers.py
+++ b/src/literature/method/ontoma/index_parsers.py
@@ -18,7 +18,8 @@ __all__ = [
     "extract_disease_entities",
     "extract_target_entities",
     "extract_drug_entities",
-    "extract_disease_curation"
+    "extract_disease_curation",
+    "as_drug_id_lut"
 ]
 
 
@@ -315,6 +316,69 @@ def extract_disease_curation(disease_curation: DataFrame) -> DataFrame:
         )
         # cleanup
         .filter((f.col("entityId").isNotNull()) & (f.length("entityId") > 0))
+        .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
+        .distinct()
+    )
+
+def as_drug_id_lut(drug_index: DataFrame) -> DataFrame:
+    """Generate drug id lookup table from the Open Targets drug index.
+
+    Args:
+        drug_index (DataFrame): Open Targets drug index.
+
+    Returns:
+        DataFrame: Drug id lookup table.
+    """
+    return (
+        drug_index
+        # filter for sources that are ids
+        .withColumn(
+            "crossReferences", 
+            f.filter(
+                f.col("crossReferences"),
+                lambda x: x["source"].isin("chEBI", "drugbank")
+            )
+        )
+        # transform array of structs to array of strings and format ids
+        .withColumn(
+            "crossReferences",
+            f.transform(
+                f.col("crossReferences"),
+                lambda x: f.when(
+                    # if it's a chEBI id, append "CHEBI_" as a prefix
+                    x["source"] == "chEBI",
+                    f.concat(f.lit("CHEBI_"), x["ids"][0])
+                ).when(
+                    # if it's a drugbank id, add an underscore between the prefix and the number
+                    x["source"] == "drugbank",
+                    f.regexp_replace(x["ids"][0], "DB", "DB_")
+                )
+                .otherwise(x["ids"][0])
+            )
+        )
+        # extract entities from relevant fields and annotate entity with score and nlpPipelineTrack
+        .select(
+            f.col("id").alias("entityId"),
+            _annotate_entity(
+                f.col("crossReferences"), 1.0, "id"
+            ).alias("crossReferences")
+        )
+        # explode array of structs
+        .withColumn(
+            "entity",
+            f.explode(
+                f.col("crossReferences"),
+            )
+        )
+        # select relevant fields and specify entity type
+        .select(
+            f.col("entityId"),
+            f.col("entity.entityLabel").alias("entityLabel"),
+            f.col("entity.entityScore").alias("entityScore"),
+            f.col("entity.nlpPipelineTrack").alias("nlpPipelineTrack"),
+            f.lit("CD").alias("entityType")
+        )
+        # cleanup
         .filter((f.col("entityLabel").isNotNull()) & (f.length("entityLabel") > 0))
         .distinct()
     )

--- a/src/literature/method/ontoma/utils.py
+++ b/src/literature/method/ontoma/utils.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from functools import reduce
 from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as f
 
 if TYPE_CHECKING:
-    from pyspark.sql import Column
+    from pyspark.sql import Column, DataFrame
 
 
 def translate_special_characters(label: Column) -> Column:
@@ -50,3 +51,43 @@ def clean_disease_label(disease_label: Column) -> Column:
             )
         ).otherwise(disease_label)
     )
+
+def filter_disease_crossrefs(disease_df: DataFrame) -> DataFrame:
+    """Filter out disease crossrefs with irrelevant prefixes.
+
+    Args:
+        disease_df (DataFrame): DataFrame containing disease crossrefs.
+
+    Returns:
+        DataFrame: DataFrame containing only the relevant disease crossrefs.
+    """
+    prefix_list = ["PMID", "DOI:", "ORCID", "PERSON", "ISBN", "WIKIPEDIA", "HTTP", "QUANT", "UM-BBD_PATHWAYID"]
+
+    filter_condition = reduce(
+        lambda cond1, cond2: cond1 | cond2,
+        [f.col("entityLabel").contains(prefix) for prefix in prefix_list],
+        f.lit(False)
+    )
+    
+    return disease_df.filter(~filter_condition)
+
+def format_disease_identifier(disease_identifier: Column) -> Column:
+    """Format disease identifier to have consistent formatting.
+
+    Args:
+        disease_identifier (Column): Column containing the disease identifier.
+
+    Returns:
+        Column: Column containing the formatted disease identifier.
+    """
+    # ensure consistent formatting across disease identifiers
+    disease_identifier = (
+        f.when(
+            f.length(f.regexp_extract(disease_identifier, r'^.+:(.+_.+)$', 1)) > 1,
+            f.regexp_extract(disease_identifier, r'^.+:(.+_.+)$', 1)
+        ).otherwise(disease_identifier)
+    )
+    disease_identifier = f.regexp_replace(disease_identifier, "_", ":")
+    
+    # ensure Orphanet identifiers are consistent
+    return f.regexp_replace(disease_identifier, r'ORDO:|ORPHA:', "ORPHANET:")


### PR DESCRIPTION
This PR adds the functions `as_disease_id_lut`, `as_target_id_lut`, and `as_drug_id_lut` that create identifier lookup tables from Open Targets indices.

This PR also adds the utility functions `filter_disease_crossrefs` and `format_disease_identifier`.