### PR TITLE
fix(schema): split EPMC read schema from Publication output schema

### DIFF
--- a/src/literature/datasource/epmc/publication.py
+++ b/src/literature/datasource/epmc/publication.py
@@ -19,8 +19,9 @@ if TYPE_CHECKING:
 class EPMCPublication:
     """Class to process publications from Europe PMC."""
 
-    # schema specifying desired subset of columns
-    defined_schema = parse_spark_schema("publication.json")
+    # schema for reading raw EPMC JSONL files; includes the `timestamp` column
+    # used internally for deduplication and dropped before the final `Publication`.
+    defined_schema = parse_spark_schema("epmc_publication.json")
 
     @classmethod
     def _read_in_with_schema(

--- a/src/literature/schemas/epmc_publication.json
+++ b/src/literature/schemas/epmc_publication.json
@@ -111,7 +111,7 @@
         "metadata": {}
       },
       {
-        "name": "traceSource",
+        "name": "timestamp",
         "type": "string",
         "nullable": true,
         "metadata": {}
@@ -119,4 +119,3 @@
     ],
     "type": "struct"
   }
-  


### PR DESCRIPTION
The Publication output schema declared `timestamp` and `kind` columns, but `_get_most_recent_publications` drops both before wrapping the DataFrame in a Publication dataset. Schema-vs-code drift was masked by those fields being nullable.

Move the read-time schema (which still needs `timestamp` for the dedup step) to a new `epmc_publication.json`, and trim `publication.json` to the actual validated output columns.

Does this make sense to you @vivienho? It makes things a bit more explicit but I don’t think if it goes too far from how you thought this