### PR TITLE
perf(match_mapped): cheapen cooccurrence self-join and section scoring

### DIFF
--- a/src/literature/dataset/match_mapped.py
+++ b/src/literature/dataset/match_mapped.py
@@ -133,7 +133,7 @@ class MatchMapped(Dataset):
         """
         return (
             df
-            .filter(f.col("isValid") == True)
+            .filter(f.col("isValid"))
             .select("pmid", "mappedId")
             .distinct()
             .withColumn("isDisambiguous", f.lit(True))
@@ -159,7 +159,7 @@ class MatchMapped(Dataset):
                     "validReasons", 
                     MatchMapped._update_flag(
                         f.col("validReasons"),
-                        (f.col("isDisambiguous") == True) & (f.col("isValid") == False),
+                        f.col("isDisambiguous") & ~f.col("isValid"),
                         IdValidReason.DISAMBIGUATED
                     )
                 )
@@ -182,7 +182,7 @@ class MatchMapped(Dataset):
             MatchMapped: Dataset with disambiguated mappings.
         """
         # only process successfully mapped matches
-        mapped_subset = self.df.filter(f.col("isMapped") == True)
+        mapped_subset = self.df.filter(f.col("isMapped"))
 
         logger.info('identify valid ids')
         annotated_df = self._identify_valid_ids(mapped_subset, trusted_sources)
@@ -204,13 +204,11 @@ class MatchMapped(Dataset):
         Returns:
             Column: Column containing score.
         """
-        score = f.lit(default_score)
+        score = f.lit(float(default_score))
 
-        # go through config from lowest to highest score
-        # if section matches pattern, assign score
+        # iterate lowest-to-highest priority so the highest-priority match wins
         for row in reversed(MatchMapped.SECTION_TO_SCORE_CONFIG):
-            pattern = r"\b(" + "|".join(row["section"]) + r")\b"
-            score = f.when(section.rlike(pattern), float(row["score"])).otherwise(score)
+            score = f.when(section.isin(row["section"]), float(row["score"])).otherwise(score)
 
         return score
 
@@ -235,16 +233,17 @@ class MatchMapped(Dataset):
                         self.df
                         .filter(f.col("type") == type2)
                         .select(
-                            "pmid", "text", 
-                            "label", "type", 
-                            "startInSentence", "endInSentence", 
+                            "pmid", "sectionStart", "sectionEnd",
+                            "label", "type",
+                            "startInSentence", "endInSentence",
                             "entityLabelNormalised", "mappedId"
                         )
                         .alias("right")
                     ),
                     on=[
                         (f.col('left.pmid') == f.col('right.pmid')) &
-                        (f.col('left.text') == f.col('right.text'))
+                        (f.col('left.sectionStart') == f.col('right.sectionStart')) &
+                        (f.col('left.sectionEnd') == f.col('right.sectionEnd'))
                     ],
                     how='inner'
                 )


### PR DESCRIPTION
## Summary
- **Self-join key.** `_generate_pairwise_cooccurrences` joined on `(pmid, text)` — a multi-hundred-byte sentence string. Switched to `(pmid, sectionStart, sectionEnd)`, which uniquely identifies a sentence within a publication and is dramatically cheaper to shuffle at corpus scale.
- **Section→score lookup.** Replaced the chain of `\b…\b` `rlike` regex predicates in `_section_to_score` with an `isin` chain. Sections come in as a small fixed vocabulary; the word-boundary regex was defensive overhead.
- **Boolean comparisons.** Dropped redundant `== True` / `== False` against already-boolean Spark columns in `disambiguate`.

Marked as draft pending validation against a real-scale run — the join-key change in particular is worth eyeballing on a representative dataset.

## Test plan
- [ ] `uv run pytest tests/` passes (covered once the test branch lands).
- [ ] Manually verify cooccurrence row counts match the previous implementation on a sample EPMC slice — the `(pmid, sectionStart, sectionEnd)` triple should produce the same matches as `(pmid, text)` if sentence offsets are well-formed.
- [ ] Eyeball `evidenceScore` distribution on a representative sample to confirm the `rlike → isin` switch hasn't dropped any sections that previously matched as substrings.