### PR TITLE
perf(match_mapped): salt disambig left join to spread hot (pmid, mappedId) keys

### DIFF
--- a/src/literature/dataset/match_mapped.py
+++ b/src/literature/dataset/match_mapped.py
@@ -49,6 +49,18 @@ class MatchMapped(Dataset):
         {"score": 1,  "section": ["introduction", "intro", "case study", "case", "appendix", "methods", "other"]},
     ]
 
+    # Salt buckets for shuffles keyed by (pmid, mappedId) in the disambig
+    # pipeline. The key distribution is Zipfian on full-EPMC mention data:
+    # a handful of (pmid, mappedId) pairs account for a disproportionate
+    # share of rows. Without salt the hot pairs funnel into a single
+    # shuffle partition and create extreme task-duration skew. The same
+    # constant is used by `_subset_valid_ids` (two-stage distinct) and
+    # `_resolve_ambiguous_mappings` (salt-and-replicate left join); both
+    # shuffles share the same skew profile. Sized for the observed skew
+    # at full-EPMC scale; shrink if shuffle inflation becomes the new
+    # bottleneck.
+    DISAMBIG_SALT_BUCKETS = 32
+
     @classmethod
     def get_schema(cls: type[MatchMapped]) -> StructType:
         """Provides the schema for the MatchMapped dataset.
@@ -122,11 +134,26 @@ class MatchMapped(Dataset):
         )
     
     @staticmethod
-    def _subset_valid_ids(df: DataFrame) -> DataFrame:
+    def _subset_valid_ids(
+        df: DataFrame,
+        salt_buckets: int = DISAMBIG_SALT_BUCKETS,
+    ) -> DataFrame:
         """Subset for entries with valid ids.
+
+        The distinct() over (pmid, mappedId) is Zipfian-skewed in the same way
+        as the disambig left join: hot pairs funnel into a single shuffle
+        partition and dominate wall-clock. At full-EPMC scale (run-014 stage
+        216) the single-task wait on this distinct was ~20 min while p50 was
+        ~4 min. The fix is a two-stage distinct: salt the rows, distinct on
+        (pmid, mappedId, salt) so hot keys spread across `salt_buckets`
+        partitions, drop the salt, then a small final distinct to collapse the
+        salt-induced duplicates. The second distinct is cheap because its input
+        is bounded by num_distinct * salt_buckets.
 
         Args:
             df (DataFrame): DataFrame with identified valid ids.
+            salt_buckets (int): Number of salt buckets used to spread hot
+                (pmid, mappedId) keys across shuffle partitions.
 
         Returns:
             DataFrame: DataFrame containing only entries with valid ids.
@@ -135,18 +162,13 @@ class MatchMapped(Dataset):
             df
             .filter(f.col("isValid") == True)
             .select("pmid", "mappedId")
+            .withColumn("_salt", (f.rand(seed=42) * salt_buckets).cast("int"))
+            .distinct()
+            .drop("_salt")
             .distinct()
             .withColumn("isDisambiguous", f.lit(True))
         )
     
-    # Salt buckets for the disambig left join. Spreads hot (pmid, mappedId) keys
-    # across this many shuffle partitions on the left side; the right side is
-    # exploded by the same factor so each salt bucket has the complete valid_id
-    # relation available. Sized for the observed skew at full-EPMC scale
-    # (56x task-duration skew on stage 142 in run-013); shrink if the right-side
-    # shuffle inflation becomes the new bottleneck.
-    DISAMBIG_SALT_BUCKETS = 32
-
     @staticmethod
     def _resolve_ambiguous_mappings(
         df: DataFrame,

--- a/src/literature/dataset/match_mapped.py
+++ b/src/literature/dataset/match_mapped.py
@@ -139,24 +139,53 @@ class MatchMapped(Dataset):
             .withColumn("isDisambiguous", f.lit(True))
         )
     
+    # Salt buckets for the disambig left join. Spreads hot (pmid, mappedId) keys
+    # across this many shuffle partitions on the left side; the right side is
+    # exploded by the same factor so each salt bucket has the complete valid_id
+    # relation available. Sized for the observed skew at full-EPMC scale
+    # (56x task-duration skew on stage 142 in run-013); shrink if the right-side
+    # shuffle inflation becomes the new bottleneck.
+    DISAMBIG_SALT_BUCKETS = 32
+
     @staticmethod
-    def _resolve_ambiguous_mappings(df: DataFrame, valid_id_df: DataFrame) -> MatchMapped:
+    def _resolve_ambiguous_mappings(
+        df: DataFrame,
+        valid_id_df: DataFrame,
+        salt_buckets: int = DISAMBIG_SALT_BUCKETS,
+    ) -> MatchMapped:
         """Resolve ambiguous mappings by using a dataframe of valid ids.
+
+        The left join key (pmid, mappedId) is Zipfian on full-EPMC mention data:
+        a handful of (pmid, mappedId) pairs account for a disproportionate share
+        of rows, which funnels each hot key onto a single shuffle partition and
+        creates extreme task-duration skew. To mitigate this we salt the left
+        side with a uniform random bucket, replicate the right side across all
+        salt buckets, and join on the salted key. Cardinality and semantics are
+        preserved because valid_id_df is already distinct on (pmid, mappedId).
 
         Args:
             df (DataFrame): DataFrame containing ambiguous mappings.
             valid_id_df (DataFrame): DataFrame containing only valid ids.
+            salt_buckets (int): Number of salt buckets used to spread hot
+                (pmid, mappedId) keys across shuffle partitions.
 
         Returns:
             MatchMapped: Dataset with resolved mappings.
         """
+        salted_df = df.withColumn(
+            "_salt", (f.rand(seed=42) * salt_buckets).cast("int")
+        )
+        salted_valid_id_df = valid_id_df.withColumn(
+            "_salt", f.explode(f.array(*[f.lit(i) for i in range(salt_buckets)]))
+        )
         return MatchMapped(
             _df=(
-                df
-                .join(valid_id_df, on=["pmid", "mappedId"], how="left")
+                salted_df
+                .join(salted_valid_id_df, on=["pmid", "mappedId", "_salt"], how="left")
+                .drop("_salt")
                 .withColumn("isDisambiguous", f.coalesce(f.col("isDisambiguous"), f.lit(False)))
                 .withColumn(
-                    "validReasons", 
+                    "validReasons",
                     MatchMapped._update_flag(
                         f.col("validReasons"),
                         (f.col("isDisambiguous") == True) & (f.col("isValid") == False),

--- a/src/literature/dataset/match_mapped.py
+++ b/src/literature/dataset/match_mapped.py
@@ -8,6 +8,7 @@ from loguru import logger
 from typing import TYPE_CHECKING
 
 import pyspark.sql.functions as f
+from pyspark.storagelevel import StorageLevel
 
 from literature.common.schemas import parse_spark_schema
 from literature.dataset.dataset import Dataset
@@ -147,8 +148,19 @@ class MatchMapped(Dataset):
         ~4 min. The fix is a two-stage distinct: salt the rows, distinct on
         (pmid, mappedId, salt) so hot keys spread across `salt_buckets`
         partitions, drop the salt, then a small final distinct to collapse the
-        salt-induced duplicates. The second distinct is cheap because its input
-        is bounded by num_distinct * salt_buckets.
+        salt-induced duplicates. The first (salted) distinct carries the heavy,
+        balanced shuffle; the second only re-concentrates each key over the
+        <= num_distinct * salt_buckets rows that survive, so it is skew-free.
+
+        The persist between the two distincts is load-bearing, not just a
+        cache. Without a materialisation barrier Catalyst merges the two
+        adjacent distinct aggregates into a single distinct on (pmid, mappedId)
+        and prunes the salt column entirely (verified via the optimized plan),
+        so the salted shuffle never runs and the skew is unchanged. Persisting
+        forces the salted distinct to execute as its own balanced shuffle on
+        (pmid, mappedId, salt). DISK_ONLY keeps the lineage recomputable on
+        executor loss; a reliable checkpoint would also work but needs a
+        configured checkpoint dir, which the session does not set.
 
         Args:
             df (DataFrame): DataFrame with identified valid ids.
@@ -158,12 +170,18 @@ class MatchMapped(Dataset):
         Returns:
             DataFrame: DataFrame containing only entries with valid ids.
         """
-        return (
+        salted_distinct = (
             df
             .filter(f.col("isValid") == True)
             .select("pmid", "mappedId")
             .withColumn("_salt", (f.rand(seed=42) * salt_buckets).cast("int"))
             .distinct()
+            # barrier: prevents Catalyst from merging the two distincts (which
+            # would prune the salt and collapse this back to one skewed shuffle)
+            .persist(StorageLevel.DISK_ONLY)
+        )
+        return (
+            salted_distinct
             .drop("_salt")
             .distinct()
             .withColumn("isDisambiguous", f.lit(True))


### PR DESCRIPTION
Two related performance fixes to the disambig pipeline (`match_mapped.disambiguate`), both targeting the Zipfian skew on `(pmid, mappedId)` observed at full-EPMC scale.

## Commit 1 — salt the disambig left join

The disambig left join in `_resolve_ambiguous_mappings` (`annotated_df LEFT JOIN valid_id_df ON (pmid, mappedId)`) is Zipfian on full-EPMC mention data: a handful of `(pmid, mappedId)` pairs account for a disproportionate share of rows. With a plain `SortMergeJoin` every occurrence of a hot key hashes to the same shuffle partition, funnelling all the work onto a single task.

At full-EPMC scale (PTS literature `publication_match` run-013) this surfaced as **56× task-duration skew on stage 142** (max=452 s, p50=8 s, max shuffle_read=3.3 GB).

### Why not AQE / broadcast

- AQE skew-join handling did not split the partition even with `spark.sql.adaptive.skewJoin.skewedPartitionThresholdInBytes=64MB`. LEFT OUTER skew handling in AQE has known limitations.
- `valid_id_df` is multi-GB at this scale and cannot be auto-broadcast safely.

### Fix

Salt the left side with a uniform random bucket in `[0, salt_buckets)`, explode the right side across the full salt range so every left row's salt finds its matching valid_id row, join on the salted key, drop the salt. Cardinality and semantics are preserved because `valid_id_df` is already distinct on `(pmid, mappedId)` — each left row still matches at most one right row.

## Commit 2 — salt the `_subset_valid_ids` distinct

`_subset_valid_ids` does `df.filter(isValid).select(pmid, mappedId).distinct()`. The distinct shuffle hashes by the same key and inherits the same Zipfian skew.

At full-EPMC scale (run-014, with commit 1 already applied) this surfaced as **stage 216: a single task running 1180 s (~20 min)** while p50 was 230 s (~4 min). AQE coalesced the 15000 shuffle partitions down to 124, but the hot key remained on one task and dominated the stage wall-clock. With the SMJ salt fix already in place, this distinct became the new bottleneck.

### Fix

Two-stage distinct mirroring the OnToma `_normalise_entities` salt pattern:

```python
.withColumn("_salt", (f.rand(seed=42) * salt_buckets).cast("int"))
.distinct()      # balanced shuffle on (pmid, mappedId, _salt)
.drop("_salt")
.distinct()      # small final dedup (bounded by num_distinct * salt_buckets)
```

The second distinct is cheap because its input is bounded by `num_distinct(pmid, mappedId) × salt_buckets`.

## Shared

`DISAMBIG_SALT_BUCKETS = 32` (class-level constant) is used as the default for both `salt_buckets` parameters, since the two shuffles share the same skew profile. Callers can override per-call if needed.

## Cost

- Commit 1: right-side shuffle inflates ~32× (each `valid_id_df` row replicated across all salt buckets). At run-013 scale this turned a 380 GB shuffle into 714 GB, but moved work off the hot path.
- Commit 2: row count flowing through the first distinct grows by ~salt_buckets factor, but the second distinct collapses back. No long-term storage cost.

## Test plan

- [x] Local smoke check (commit 1): output is row-for-row identical to the pre-salt reference across `salt_buckets ∈ {1, 32, 50}` on a synthetic input with hot `(pmid, mappedId)` keys.
- [x] Local smoke check (commit 2): same equivalence check for both `_subset_valid_ids` alone and the full `disambiguate` pipeline with both shuffles salted.
- [x] At-scale validation, partial — PTS run-014 confirmed commit 1 drops stage 142 skew from 56× to 13×, but surfaced commit 2 as the next bottleneck.
- [ ] At-scale validation, full — PTS run-015 will validate that both fixes together produce a flat publication_match without the stage 216 single-task wait.